### PR TITLE
updating com timeout

### DIFF
--- a/tigerasi/tiger_controller.py
+++ b/tigerasi/tiger_controller.py
@@ -30,7 +30,7 @@ class TigerController:
 
     # Constants
     BAUD_RATE = 115200
-    TIMEOUT = 5
+    TIMEOUT = 1
 
     def __init__(self, com_port):
         self.ser = None


### PR DESCRIPTION
Shorten the timeout on communication coms with Tiger devices. This greatly reduces the wait time to command the filterwheel right now, which currently appears to timeout on a response.

Testing: this has been running on the mesospim for the last month or so.