### PR TITLE
updated python version. moved print statements to a logger

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -21,6 +21,6 @@ setuptools.setup(
         "License :: OSI Approved :: MIT License",
         "Operating System :: POSIX :: Linux",
     ],
-    python_requires='>=3.6',
+    python_requires='>=3.9',
     install_requires=[]
 )


### PR DESCRIPTION
I'm using the `@cache` decorator, which is a python 3.9+ feature.
I also moved print statements to a logger.