### PR TITLE
updating travel limit reset funcs when called with no axes

### DIFF
--- a/tigerasi/tiger_controller.py
+++ b/tigerasi/tiger_controller.py
@@ -272,7 +272,10 @@ class TigerController:
     def reset_lower_travel_limits(self, *args: str,
                                   wait_for_output: bool = True,
                                   wait_for_reply: bool = True):
-        """Restore lower travel limit on specified axes to firmware defaults."""
+        """Restore lower travel limit on specified axes (or all if none are
+        specified) to firmware defaults."""
+        if not args:
+            args = self.ordered_axes
         return self._reset_setting(Cmds.SETLOW, *args,
                                    wait_for_output=wait_for_output,
                                    wait_for_reply=wait_for_reply)
@@ -318,7 +321,10 @@ class TigerController:
     def reset_upper_travel_limits(self, *args: str,
                                   wait_for_output: bool = True,
                                   wait_for_reply: bool = True):
-        """Restore lower travel limit on specified axes to firmware defaults."""
+        """Restore upper travel limit on specified axes (or all axes if none
+         are specified) to firmware defaults."""
+        if not args:
+            args = self.ordered_axes
         return self._reset_setting(Cmds.SETUP, *args,
                                    wait_for_output=wait_for_output,
                                    wait_for_reply=wait_for_reply)


### PR DESCRIPTION
Addresses https://github.com/AllenNeuralDynamics/TigerASI/issues/28

calling **reset_lower_travel_limit()** and **reset_upper_travel_limit()** (i.e: without specified axes) will reset all lower and upper travel limits. 