### PR TITLE
Wait Edge Case

### DIFF
--- a/tigerasi/tiger_controller.py
+++ b/tigerasi/tiger_controller.py
@@ -748,7 +748,8 @@ class TigerController:
 
     def wait(self):
         """Block until tigerbox is idle."""
-        return not self.is_moving()
+        while self.is_moving():
+            pass
 
     def clear_incoming_message_queue(self):
         """Clear input buffer and reset skipped replies."""


### PR DESCRIPTION
Fixes a bug where we wait a minimum time post issuing a command (without a reply) before checking if the device is busy. (Handles the case where a command has been sent to the tigerbox, but the box has not had enough time to process it and send a reply.)