### PR TITLE
Dev/ttl implementation

### DIFF
--- a/tigerasi/device_codes.py
+++ b/tigerasi/device_codes.py
@@ -125,6 +125,7 @@ class RingBufferMode(Enum):
     ONE_SHOT = 1
     REPEATING = 2
 
+
 class TTLIn0Mode(Enum):
     OFF = 0
     MOVE_TO_NEXT_ABS_POSITION = 1

--- a/tigerasi/tiger_controller.py
+++ b/tigerasi/tiger_controller.py
@@ -803,7 +803,7 @@ class TigerController:
     def clear_ring_buffer(self, wait_for_reply: bool = True,
                           wait_for_output: bool = True):
         kwds = {'X': 0}
-        self._set_cmd_args_and_kwds(Cmds.RBMODE, kwds,
+        self._set_cmd_args_and_kwds(Cmds.RBMODE, **kwds,
                                     wait_for_reply=wait_for_reply,
                                     wait_for_output=wait_for_output)
 
@@ -837,6 +837,7 @@ class TigerController:
                                     wait_for_reply=wait_for_reply,
                                     wait_for_output=wait_for_output)
 
+    @axis_check('wait_for_reply', 'wait_for_output')
     def queue_buffered_move(self, wait_for_reply: bool = True,
                             wait_for_output: bool = True, **axes: float,):
         """Push a move (relative or absolute depends on context) into the


### PR DESCRIPTION
A monster PR. Here's the breakdown.

### Big Stuff
* Tigerbox ring buffer interface implemented. You can now reset the ring buffer or add moves to it. (This was tested in hardware and is how the exa-spim acquisition loop is coded in the dev/classified branch.
* Tigerbox TTL settings can now be set from this driver using enums. (addresses https://github.com/AllenNeuralDynamics/TigerASI/issues/36)
* Tigerbox ARRAY interface implemented. We lack the current firmware module to test this though.

### Other stuff
* tweaked the `@axis_check` decorator to be more general purpose. (addresses https://github.com/AllenNeuralDynamics/TigerASI/issues/19) (This is a decorator that goes on any function that can take any number of axis arguments. It ensures that the axes the user specified actually exist on the Tigerbox.)

For examples on how these things get called, check out the mesospim repo:
* [example using the ring buffer](https://github.com/AllenNeuralDynamics/mesospim-prime/blob/dev/spim_parity/mesospim/devices/tiger_components.py#L212). Tested and is used on current exa-spim-control dev branch.
* [example using the array command](https://github.com/AllenNeuralDynamics/mesospim-prime/blob/dev/spim_parity/mesospim/devices/tiger_components.py#L228). Untested.
