### PR TITLE
Get axis info

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -7,7 +7,7 @@
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#project-information
 
 project = 'TigerASI'
-copyright = '2022, poofjunior, adamkglaser'
+copyright = '2023, poofjunior, adamkglaser'
 author = 'poofjunior, adamkglaser'
 release = '0.0.1'
 
@@ -15,8 +15,8 @@ release = '0.0.1'
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration
 
 extensions = [
-    "sphinx.ext.autodoc",  # enable doc generation from code docstrings.
     "sphinx.ext.napoleon",  # enable numpy and google style docstring parsing.
+    "sphinx.ext.autodoc",  # enable doc generation from code docstrings.
 ]
 
 templates_path = ['_templates']
@@ -38,7 +38,7 @@ html_theme_options = {
 }
 html_sidebars = {'**': ['localtoc.html', 'sourcelink.html',
                         'searchbox.html', 'globaltoc.html']}
-html_static_path = ['_static']
+html_static_path = []  #['_static']
 
 # Sphinx Options.
 autoclass_content = 'both'

--- a/examples/dump_axis_settings.py
+++ b/examples/dump_axis_settings.py
@@ -14,8 +14,9 @@ ordered_axes = build_config['Motor Axes']
 settings = {}
 for axis in ordered_axes:
     axis_settings = box.get_info(axis)
+    print(f"Axis: {axis}")
     pprint.pprint(axis_settings)
-    settings[f'{axis} Axis']=axis_settings
+    settings[f'{axis} Axis'] = axis_settings
 
 with open("tiger_settings.json", "w") as outfile:
     json.dump(settings, outfile, indent=4)

--- a/examples/get_etl_temp.py
+++ b/examples/get_etl_temp.py
@@ -3,6 +3,14 @@
 
 from tigerasi.tiger_controller import TigerController
 
+# Uncomment for some prolific log statements.
+# import logging
+# logger = logging.getLogger()
+# logger.setLevel(logging.DEBUG)
+# logger.addHandler(logging.StreamHandler())
+# logger.handlers[-1].setFormatter(
+#    logging.Formatter(fmt='%(asctime)s:%(levelname)s: %(message)s'))
+
 PORT_NAME = "COM3"
 print("Connecting to Tiger Controller... ", end=" ", flush=True)
 box = TigerController(PORT_NAME)

--- a/tigerasi/device_codes.py
+++ b/tigerasi/device_codes.py
@@ -2,6 +2,7 @@
 """TigerController Device Codes"""
 from enum import Enum
 
+ACK = ":A"  # device acknowledgment for some axis-specific commands.
 
 class Cmds(Enum):
     # Common commands in bytes form.


### PR DESCRIPTION
1. Added the ```INFO``` command into the ```get_info()``` function. Implementation details. 

The function checks for a valid axis, issues the command, and then parses the replies into a ```dict```. The formatting of the replies are two columns of settings, separated by a constant character offset of 33. The current code implementation stores this in a ```GET_INFO_STRING_SPLIT``` and parses the dictionary within the function. Instead of through a separate low level function. 

There is an example added ```dump_axis_settings.py```.

2. Added ```get_etl_temp()``` to output the ETL temperature. Implementation details. 

- Had to add a ```_get_axis_to_type_mapping()``` function which mirrors the ```get_axis_to_card_mapping()``` implementation. 
- The type is used to first check whether the specified axis is a valid tunable lens axis -> needs to have ```'b '``` as the type. 
- Had to add a ```get_pm()``` function to determine the initial ```PM``` setting of the axis so that it can reset it to the original setting after querying the temperature. 
- The ETL temperature cannot be read out when it is in external control mode (default for us). so the axis then needs to be set to internal mode with temperature compensation, i.e. ```PM = 2```. added a ```ControlMode.INTERNAL_OPEN_LOOP``` for this.
- Then the ```PZINFO``` command is sent, and the reply is parsed to extract the temperature. (6) the axis is returned to the initial ```PM``` setting.

There is an example added ```get_etl_temp.py```.
