### PR TITLE
API Cleaup

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,21 @@ box.set_home('x', 'z', y=100.0) # Set x and z axes homing location to current sp
 box.set_home('z', 'y', 'x', m=100.0, n=200.0) # variable number of arguments ok! order and case don't matter.
 ````
 
+Some commands assume *all* axes if none are specified.
+````python
+box.zero_in_place()  # will zero ALL lettered axes.
+box.reset_lower_travel_limits()  # will reset ALL lettered axes.
+
+box.get_home()  # will get ALL lettered axis home positions.
+box.get_lower_travel_limits() # will get ALL lettered axis lower travel limits.
+````
+
+For setting values, this might not be your desired behavior, so it is better to pass in axes explicitly.
+````python
+box.zero_in_place('x', 'y', 'z')  # will zero only x, y, and z axes.
+box.reset_lower_travel_limits('x', 'y', 'z')  # will reset only x, y, and z axes.
+````
+
 ## Advanced Usage
 Many (but not all!) of ASI's more advanced features have been made available via this simplified API.
 This list includes joystick enabling/disabling and remapping, setting stage travel limits, queuing moves into the hardware buffer, and many other more nuanced features.

--- a/README.md
+++ b/README.md
@@ -20,8 +20,8 @@ box = TigerController("COM4")
 The basic command syntax looks like this:
 ````python
 box.zero_in_place('x', 'y')  # Zero out the specified axes at their current location.
-box.move_axes_absolute(x=1000, y=25)  # Move to an absolute location in "stage units" (tenths of microns).
-box.move_axes_relative(z=100) # Move z +100 stage units in the positive z direction.
+box.move_absolute(x=1000, y=25)  # Move to an absolute location in "stage units" (tenths of microns).
+box.move_relative(z=100) # Move z +100 stage units in the positive z direction.
 ````
 
 ### Syntax Basics
@@ -69,7 +69,7 @@ Commands that query the Tigerbox state will also return data with that reply.
 Waiting for a reply introduces 10-20[ms] of execution time before the function returns.
 By default, methods *will block* until receiving this reply unless otherwise specified, like this:
 ````
-box.move_axes_absolute(x=1000, y=25, wait_for_output=False, wait_for_reply=False) # will not block.
+box.move_absolute(x=1000, y=25, wait_for_output=False, wait_for_reply=False) # will not block.
 ````
 This behavior can only be used for commands to change the Tigerbox state.
 Commands that query the Tigerbox state will always block until they receive a hardware reply.

--- a/README.md
+++ b/README.md
@@ -60,11 +60,12 @@ box.get_home()  # will get ALL lettered axis home positions.
 box.get_lower_travel_limits() # will get ALL lettered axis lower travel limits.
 ````
 
-For setting values, this might not be your desired behavior, so it is better to pass in axes explicitly.
+For setting values, this might not be your desired behavior, so it is safer to default to passing in axes explicitly.
 ````python
 box.zero_in_place('x', 'y', 'z')  # will zero only x, y, and z axes.
 box.reset_lower_travel_limits('x', 'y', 'z')  # will reset only x, y, and z axes.
 ````
+When in doubt, check the docs.
 
 ## Advanced Usage
 Many (but not all!) of ASI's more advanced features have been made available via this simplified API.

--- a/examples/interactive_set_stage_limit.py
+++ b/examples/interactive_set_stage_limit.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 """Connects to the Tiger Box, moves some axes, returns to starting pose."""
 
-from tigerasi.tiger_controller import TigerController, UM_TO_STEPS
+from tigerasi.tiger_controller import TigerController, STEPS_PER_UM
 from tigerasi.device_codes import ScanPattern
 import pprint
 import time
@@ -39,13 +39,13 @@ for x in axes:
     input(f"Use the joystick to move to the LOWER travel limit of {x.upper()}."
           f" Press enter when ready.")
     axis_pos_dict = box.get_position(x)
-    axis_pos_dict_mm = {x: v/UM_TO_STEPS/1000.
+    axis_pos_dict_mm = {x: v / STEPS_PER_UM / 1000.
                         for x, v in axis_pos_dict.items()}
     box.set_lower_travel_limit(**axis_pos_dict_mm)
     input(f"Use the joystick to move to the UPPER travel limit of {x.upper()}."
           f" Press enter when ready.")
     axis_pos_dict = box.get_position(x)
-    axis_pos_dict_mm = {x: v / UM_TO_STEPS / 1000.
+    axis_pos_dict_mm = {x: v / STEPS_PER_UM / 1000.
                         for x, v in axis_pos_dict.items()}
     box.set_upper_travel_limit(**axis_pos_dict_mm)
 

--- a/examples/tigerasi_speed_and_halt.py
+++ b/examples/tigerasi_speed_and_halt.py
@@ -44,11 +44,11 @@ box.zero_in_place()
 print(f"box position is: {box.get_position('x', 'y', 'z')}")
 # Send a relative move cmd.
 print("moving an axis.")
-box.move_axes_relative(x=2000)
+box.move_relative(x=2000)
 sleep(0.05)
 # halt immediately after.
 print("halting.")
 box.halt()
 # read the position.
 print(f"box position is: {box.get_position('x', 'y', 'z')}")
-box.move_axes_absolute(x=0)
+box.move_absolute(x=0)

--- a/tigerasi/sim_tiger_controller.py
+++ b/tigerasi/sim_tiger_controller.py
@@ -31,7 +31,7 @@ class TigerController:
 
     # High-Level Commands
     @axis_check('wait_for_reply', 'wait_for_output')
-    def move_axes_relative(self, wait_for_output=True, wait_for_reply=True,
+    def move_relative(self, wait_for_output=True, wait_for_reply=True,
                            **kwargs: int):
         """move the axes specified in kwargs by a relative amount.
 
@@ -42,7 +42,7 @@ class TigerController:
         # TODO; add some sleeping here.
 
     @axis_check('wait_for_reply', 'wait_for_output')
-    def move_axes_absolute(self, wait_for_output=True, wait_for_reply=True,
+    def move_absolute(self, wait_for_output=True, wait_for_reply=True,
                            **kwargs: int):
         """move the axes specified in kwargs by the specified absolute amount (in tenths of microns)."""
         axes_str = ""

--- a/tigerasi/tiger_controller.py
+++ b/tigerasi/tiger_controller.py
@@ -123,8 +123,8 @@ class TigerController:
 
         .. code-block:: python
 
-            box.move_axis_relative(x=10, y=20)  # Move 1 micron in x and 2 in y
-            box.move_axis_relative(z=100)  # Move 10 microns in z
+            box.move_relative(x=10, y=20)  # Move 1 micron in x and 2 in y
+            box.move_relative(z=100)  # Move 10 microns in z
 
         """
         self._set_cmd_args_and_kwds(Cmds.MOVEREL, **axes, wait=wait)
@@ -141,7 +141,7 @@ class TigerController:
 
         .. code-block:: python
 
-            box.move_axis_absolute(x=0, y=100)  # Move x and y axes to absolute location.
+            box.move_absolute(x=0, y=100)  # Move x and y axes to absolute location.
 
         """
         self._set_cmd_args_and_kwds(Cmds.MOVEABS, **axes, wait=wait)

--- a/tigerasi/tiger_controller.py
+++ b/tigerasi/tiger_controller.py
@@ -565,7 +565,7 @@ class TigerController:
         # TODO: figure out which axis type it is and return that type of enum.
         return control_num
 
-    def start_scan(self, wait: bool = True)
+    def start_scan(self, wait: bool = True):
         #TODO: Figure out how to make command below work
         # self.scan(ScanState.START)
         cmd_str = Cmds.SCAN.value + '\r'

--- a/tigerasi/tiger_controller.py
+++ b/tigerasi/tiger_controller.py
@@ -303,7 +303,7 @@ class TigerController:
         :param kwd_axes: axes to specify input position as the upper limit.
         :param wait: wait until the reply has been received.
 
-        ..code_block::
+        .. code-block:: python
 
             box.set_upper_travel_limit('x', 'y')  # current positions as limit OR
             box.set_upper_travel_limit(x=50, y=4.0)  # specific positions as limit OR
@@ -437,7 +437,7 @@ class TigerController:
         self._set_cmd_args_and_kwds(Cmds.J, **axes)
 
     @axis_check()
-    def get_joystick_axis_mapping(self, *axes):
+    def get_joystick_axis_mapping(self, *axes: str):
         """Get the axis mapping currently set on the joystick for the requested
             axes (or all if none are requested)
 
@@ -472,7 +472,7 @@ class TigerController:
         self.enable_joystick_inputs(*axes.keys())
 
     @axis_check()
-    def enable_joystick_inputs(self, *axes):
+    def enable_joystick_inputs(self, *axes: str):
         """Enable specified (or all if none are specified) axis control through
         the joystick.
 
@@ -491,7 +491,7 @@ class TigerController:
         return self._set_cmd_args_and_kwds(Cmds.J, *enabled_axes)
 
     @axis_check()
-    def disable_joystick_inputs(self, *axes):
+    def disable_joystick_inputs(self, *axes: str):
         """Disable specified (or all if none are specified) axis control
         through the joystick.
 
@@ -566,12 +566,14 @@ class TigerController:
         return control_num
 
     def start_scan(self, wait: bool = True):
+        """Start a scan that has been previously setup with scanr and scanv."""
         #TODO: Figure out how to make command below work
         # self.scan(ScanState.START)
         cmd_str = Cmds.SCAN.value + '\r'
         self.send(cmd_str, wait=wait)
 
     def stop_scan(self):
+        """Stop an active scan."""
         self.scan(ScanState.STOP)
 
     def scanr(self, scan_start_mm: float, scan_stop_mm: float = None,

--- a/tigerasi/tiger_controller.py
+++ b/tigerasi/tiger_controller.py
@@ -9,7 +9,7 @@ from typing import Union
 import logging
 
 # Constants
-UM_TO_STEPS = 10.0  # multiplication constant to convert micrometers to steps.
+STEPS_PER_UM = 10.0  # multiplication constant to convert micrometers to steps.
 MM_SCALE = 4
 DEG_SCALE = 3
 REPLY_WAIT_TIME_S = 0.020  # minimum time to wait for a reply after having

--- a/tigerasi/tiger_controller.py
+++ b/tigerasi/tiger_controller.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 """TigerController Serial Port Abstraction"""
 from enum import Enum
 from serial import Serial, SerialException
@@ -114,7 +113,7 @@ class TigerController:
 
     # High-Level Commands
     @axis_check('wait')
-    def move_axes_relative(self, wait: bool = True, **axes: int):
+    def move_relative(self, wait: bool = True, **axes: int):
         """Move the axes specified by a relative amount.
 
         Note: Units are in tenths of microns.
@@ -133,7 +132,7 @@ class TigerController:
         self._last_rel_move_axes = [x for x in axes if x in self.axes]
 
     @axis_check('wait')
-    def move_axes_absolute(self, wait: bool = True, **axes: int):
+    def move_absolute(self, wait: bool = True, **axes: int):
         """move the axes specified by the specified absolute amount
         (in tenths of microns). Unspecified axes will not be moved.
 


### PR DESCRIPTION
**Note**. We must also merge https://github.com/AllenNeuralDynamics/dispim-control/pull/46 at the same time.

## Summary
API cleanup including:
* `wait_for_reply` and `wait_for_output` keyword arguments have been replaced with `wait`
* `UM_TO_STEPS` constant was replaced with `STEPS_PER_UM`
* `args` parameter has been replaced to `axes`
* `kwargs` parameter has been replaced to `axes` or `kwd_axes` when `axes` is already specified as `*args`
* remove magic number 4 as the number of decimal places in a value specified in millimeters

## TODOs
Since this is a big change, let's squash-merge with a commit that starts with `feat` to trigger the github action to update the minor release number.
