### PR TITLE
adding ENC_INT device code

### DIFF
--- a/src/tigerasi/device_codes.py
+++ b/src/tigerasi/device_codes.py
@@ -67,6 +67,8 @@ class ErrorCodes(Enum):
 class FirmwareModules(Enum):
     SCAN_MODULE = "SCAN MODULE"
     ARRAY_MODULE = "ARRAY MODULE"
+    ENC_INT = "ENC INT"
+    IN0_INT = "IN0 INT"
 
 
 class JoystickInput(Enum):

--- a/src/tigerasi/tiger_controller.py
+++ b/src/tigerasi/tiger_controller.py
@@ -1018,6 +1018,12 @@ class TigerController:
         # Aggregate specified params.
         param_str = f"{in0_str}{out0_str}{auxstate_str}{polarity_str}" \
                     f"{auxmask_str}{auxmode_str}".rstrip()
+        # Check that SCAN_MODULE, ENC_INT, or IN0_INT firmware exists.
+        if in0_mode == TTLIn0Mode.ENC_INT:
+            self._has_firmware(self._scan_card_addr,
+                               [FirmwareModules.SCAN_MODULE,
+                                FirmwareModules.ENC_INT,
+                                FirmwareModules.IN0_INT])
         # Infer address of card or cards for a repeated move.
         if in0_mode == TTLIn0Mode.REPEAT_LAST_REL_MOVE and card_address is None:
             cards = {self.axis_to_card[x][0] for x in self._last_rel_move_axes}


### PR DESCRIPTION
Adding ENC_INT device code for TTL IN mode, has same X=1 value as MOVE_NEXT_ABS position https://asiimaging.com/docs/scan_module.